### PR TITLE
Repurpose and rename Revise Status

### DIFF
--- a/data-model/src/main/java/org/cancermodels/types/Status.java
+++ b/data-model/src/main/java/org/cancermodels/types/Status.java
@@ -3,7 +3,7 @@ package org.cancermodels.types;
 public enum Status {
   UNMAPPED("Unmapped"),
   MAPPED("Mapped"),
-  REVISE("Revise"),
+  REVIEW("Review"),
   REQUEST("Request");
 
   private final String label;

--- a/rest/src/main/java/org/cancermodels/admin/MappingRulesController.java
+++ b/rest/src/main/java/org/cancermodels/admin/MappingRulesController.java
@@ -57,7 +57,7 @@ public class MappingRulesController {
   /**
    * Deletes all the mapping entities and reload the data from the json files with the mapping rules.
    * Because the json files contain only Mapped data, any mappings in other status
-   * (Revise, Unmapped, Request) will be lost.
+   * (Review, Unmapped, Request) will be lost.
    */
   @GetMapping("/restoreMappedMappingEntitiesFromJsons")
   public void getSimilar() throws IOException {

--- a/services/src/main/java/org/cancermodels/mapping_rules/MappingRulesService.java
+++ b/services/src/main/java/org/cancermodels/mapping_rules/MappingRulesService.java
@@ -104,7 +104,7 @@ public class MappingRulesService {
   /**
    * Deletes all the mapping entities and reload the data from the json files with the mapping rules.
    * Because the json files contain only Mapped data, any mappings in other status
-   * (Revise, Unmapped, Request) will be lost.
+   * (Review, Unmapped, Request) will be lost.
    */
   public void restoreMappedMappingEntitiesFromJsons() throws IOException {
     mappingEntityService.deleteAll();

--- a/services/src/main/java/org/cancermodels/mappings/automatic_mappings/AutomaticMappingsService.java
+++ b/services/src/main/java/org/cancermodels/mappings/automatic_mappings/AutomaticMappingsService.java
@@ -195,7 +195,7 @@ public class AutomaticMappingsService {
     String mappingType = MappingType.AUTOMATIC.getLabel();
     LocalDateTime updateTime = LocalDateTime.now();
     String sourceType = suggestion.getSourceType();
-    String status = Status.MAPPED.getLabel();
+    String status = Status.REVIEW.getLabel();
 
     mappingEntity.setMappedTermUrl(mappedTermUrl);
     mappingEntity.setMappedTermLabel(mappedTermLabel);

--- a/services/src/test/java/org/cancermodels/general/MappingEntityBuilder.java
+++ b/services/src/test/java/org/cancermodels/general/MappingEntityBuilder.java
@@ -9,6 +9,7 @@ import org.cancermodels.persistance.EntityType;
 import org.cancermodels.persistance.MappingEntity;
 import org.cancermodels.persistance.MappingKey;
 import org.cancermodels.persistance.MappingValue;
+import org.cancermodels.types.Status;
 
 public class MappingEntityBuilder {
 
@@ -21,6 +22,8 @@ public class MappingEntityBuilder {
   private List<MappingValue> mappingValues = new ArrayList<>();
   private String mappedTermUrl;
 
+  private String status;
+
   public MappingEntity build() {
     MappingEntity mappingEntity = new MappingEntity();
     mappingEntity.setId(id);
@@ -28,6 +31,7 @@ public class MappingEntityBuilder {
     mappingEntity.setMappingValues(mappingValues);
     mappingEntity.setMappedTermUrl(mappedTermUrl);
     mappingEntity.setMappingKey(mappingKey);
+    mappingEntity.setStatus(status);
     return mappingEntity;
   }
 
@@ -63,6 +67,11 @@ public class MappingEntityBuilder {
 
   public MappingEntityBuilder setMappedTermUrl(String mappedTermUrl) {
     this.mappedTermUrl = mappedTermUrl;
+    return this;
+  }
+
+  public MappingEntityBuilder setStatus(Status status) {
+    this.status = status.getLabel();
     return this;
   }
 

--- a/services/src/test/java/org/cancermodels/mappings/MappingEntityUpdaterTest.java
+++ b/services/src/test/java/org/cancermodels/mappings/MappingEntityUpdaterTest.java
@@ -1,0 +1,289 @@
+package org.cancermodels.mappings;
+
+import org.cancermodels.EntityTypeName;
+import org.cancermodels.general.MappingEntityBuilder;
+import org.cancermodels.persistance.MappingEntity;
+import org.cancermodels.persistance.MappingEntityRepository;
+import org.cancermodels.types.MappingType;
+import org.cancermodels.types.Status;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.time.LocalDateTime;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MappingEntityUpdaterTest {
+
+    @Mock
+    private MappingEntityRepository mappingEntityRepository;
+    private MappingEntityUpdater instance;
+
+    private final MappingEntityBuilder mappingEntityBuilder = new MappingEntityBuilder();
+
+    @BeforeEach
+    public void setup()
+    {
+        instance = new MappingEntityUpdater(mappingEntityRepository);
+    }
+
+    @Test
+    void update_unchangedEntityTypeManual_saveMethodNotCalled() {
+        MappingEntity original = mappingEntityBuilder
+            .setEntityType(EntityTypeName.Treatment)
+            .setValues(MappingEntityBuilder.createTreatmentValues("TRACE", "Aspirin"))
+            .setStatus(Status.UNMAPPED)
+            .build();
+        MappingEntity withChanges = original;
+        MappingEntity result = instance.update(original, withChanges, MappingType.MANUAL);
+
+        verify(mappingEntityRepository, never()).save(result);
+        assertEquals(original.getDateUpdated(), result.getDateUpdated());
+    }
+
+    @Test
+    void update_mappedTermChanged_entityUpdatedAndSaveMethodCalled() {
+        MappingEntity original = mappingEntityBuilder
+            .setEntityType(EntityTypeName.Treatment)
+            .setValues(MappingEntityBuilder.createTreatmentValues("TRACE", "Aspirin"))
+            .setStatus(Status.MAPPED)
+            .setMappedTermUrl("url1")
+            .build();
+        LocalDateTime yesterday = LocalDateTime.now().minusDays(1);
+        original.setDateUpdated(yesterday);
+
+        MappingEntity withChanges = mappingEntityBuilder
+            .setEntityType(EntityTypeName.Treatment)
+            .setValues(MappingEntityBuilder.createTreatmentValues("TRACE", "Aspirin"))
+            .setStatus(Status.MAPPED)
+            .setMappedTermUrl("url2")
+            .build();
+        withChanges.setDateUpdated(yesterday);
+
+        MappingEntity result = instance.update(original, withChanges, MappingType.MANUAL);
+
+        verify(mappingEntityRepository).save(result);
+        assertTrue(result.getDateUpdated().isAfter(yesterday), "Update date didn't change");
+        assertEquals(withChanges.getMappedTermUrl(), result.getMappedTermUrl());
+        assertEquals(withChanges.getSource(), result.getSource());
+        assertEquals(withChanges.getMappedTermLabel(), result.getMappedTermLabel());
+        assertEquals(withChanges.getEntityType(), result.getEntityType());
+
+    }
+
+    @Test
+    void update_statusChangedUnmappedToMapped_statusAndDateUpdatedAndSaveMethodCalled() {
+        MappingEntity original = mappingEntityBuilder
+            .setEntityType(EntityTypeName.Treatment)
+            .setValues(MappingEntityBuilder.createTreatmentValues("TRACE", "Aspirin"))
+            .setStatus(Status.UNMAPPED)
+            .build();
+        LocalDateTime yesterday = LocalDateTime.now().minusDays(1);
+        original.setDateUpdated(yesterday);
+
+        MappingEntity withChanges = mappingEntityBuilder
+            .setEntityType(EntityTypeName.Treatment)
+            .setValues(MappingEntityBuilder.createTreatmentValues("TRACE", "Aspirin"))
+            .setStatus(Status.MAPPED)
+            .setMappedTermUrl("url2")
+            .build();
+
+        MappingEntity result = instance.update(original, withChanges, MappingType.MANUAL);
+
+        verify(mappingEntityRepository).save(result);
+        assertTrue(result.getDateUpdated().isAfter(yesterday), "Update date didn't change");
+        assertEquals(withChanges.getMappedTermUrl(), result.getMappedTermUrl());
+        assertEquals(withChanges.getSource(), result.getSource());
+        assertEquals(withChanges.getMappedTermLabel(), result.getMappedTermLabel());
+        assertEquals(withChanges.getEntityType(), result.getEntityType());
+
+    }
+
+    @Test
+    void update_statusChangedUnmappedToRequest_statusAndDateUpdatedAndSaveMethodCalled() {
+        MappingEntity original = mappingEntityBuilder
+            .setEntityType(EntityTypeName.Treatment)
+            .setValues(MappingEntityBuilder.createTreatmentValues("TRACE", "Aspirin"))
+            .setStatus(Status.UNMAPPED)
+            .build();
+        LocalDateTime yesterday = LocalDateTime.now().minusDays(1);
+        original.setDateUpdated(yesterday);
+
+        MappingEntity withChanges = mappingEntityBuilder
+            .setEntityType(EntityTypeName.Treatment)
+            .setValues(MappingEntityBuilder.createTreatmentValues("TRACE", "Aspirin"))
+            .setStatus(Status.REQUEST)
+            .build();
+
+        MappingEntity result = instance.update(original, withChanges, MappingType.MANUAL);
+
+        verify(mappingEntityRepository).save(result);
+        assertTrue(result.getDateUpdated().isAfter(yesterday), "Update date didn't change");
+        assertEquals(withChanges.getMappedTermUrl(), result.getMappedTermUrl());
+        assertEquals(withChanges.getSource(), result.getSource());
+        assertEquals(withChanges.getMappedTermLabel(), result.getMappedTermLabel());
+        assertEquals(withChanges.getEntityType(), result.getEntityType());
+    }
+
+    @Test
+    void update_statusChangedUnmappedToReviewTypeAutomatic_statusAndDateUpdatedAndSaveMethodCalled() {
+        MappingEntity original = mappingEntityBuilder
+            .setEntityType(EntityTypeName.Treatment)
+            .setValues(MappingEntityBuilder.createTreatmentValues("TRACE", "Aspirin"))
+            .setStatus(Status.UNMAPPED)
+            .build();
+        LocalDateTime yesterday = LocalDateTime.now().minusDays(1);
+        original.setDateUpdated(yesterday);
+
+        MappingEntity withChanges = mappingEntityBuilder
+            .setEntityType(EntityTypeName.Treatment)
+            .setValues(MappingEntityBuilder.createTreatmentValues("TRACE", "Aspirin"))
+            .setStatus(Status.REVIEW)
+            .build();
+
+        MappingEntity result = instance.update(original, withChanges, MappingType.AUTOMATIC);
+
+        verify(mappingEntityRepository).save(result);
+        assertTrue(result.getDateUpdated().isAfter(yesterday), "Update date didn't change");
+        assertEquals(withChanges.getMappedTermUrl(), result.getMappedTermUrl());
+        assertEquals(withChanges.getSource(), result.getSource());
+        assertEquals(withChanges.getMappedTermLabel(), result.getMappedTermLabel());
+        assertEquals(withChanges.getEntityType(), result.getEntityType());
+    }
+
+    @Test
+    void update_statusChangedRequestToUnmapped_statusAndDateUpdatedAndSaveMethodCalled() {
+        MappingEntity original = mappingEntityBuilder
+            .setEntityType(EntityTypeName.Treatment)
+            .setValues(MappingEntityBuilder.createTreatmentValues("TRACE", "Aspirin"))
+            .setStatus(Status.REQUEST)
+            .build();
+        LocalDateTime yesterday = LocalDateTime.now().minusDays(1);
+        original.setDateUpdated(yesterday);
+
+        MappingEntity withChanges = mappingEntityBuilder
+            .setEntityType(EntityTypeName.Treatment)
+            .setValues(MappingEntityBuilder.createTreatmentValues("TRACE", "Aspirin"))
+            .setStatus(Status.UNMAPPED)
+            .build();
+
+        MappingEntity result = instance.update(original, withChanges, MappingType.MANUAL);
+
+        verify(mappingEntityRepository).save(result);
+        assertTrue(result.getDateUpdated().isAfter(yesterday), "Update date didn't change");
+        assertEquals(withChanges.getMappedTermUrl(), result.getMappedTermUrl());
+        assertEquals(withChanges.getSource(), result.getSource());
+        assertEquals(withChanges.getMappedTermLabel(), result.getMappedTermLabel());
+        assertEquals(withChanges.getEntityType(), result.getEntityType());
+    }
+
+    @Test
+    void update_statusChangedMappedToReview_statusAndDateUpdatedAndSaveMethodCalled() {
+        MappingEntity original = mappingEntityBuilder
+            .setEntityType(EntityTypeName.Treatment)
+            .setValues(MappingEntityBuilder.createTreatmentValues("TRACE", "Aspirin"))
+            .setStatus(Status.MAPPED)
+            .build();
+        LocalDateTime yesterday = LocalDateTime.now().minusDays(1);
+        original.setDateUpdated(yesterday);
+
+        MappingEntity withChanges = mappingEntityBuilder
+            .setEntityType(EntityTypeName.Treatment)
+            .setValues(MappingEntityBuilder.createTreatmentValues("TRACE", "Aspirin"))
+            .setStatus(Status.REVIEW)
+            .build();
+
+        MappingEntity result = instance.update(original, withChanges, MappingType.MANUAL);
+
+        verify(mappingEntityRepository).save(result);
+        assertTrue(result.getDateUpdated().isAfter(yesterday), "Update date didn't change");
+        assertEquals(withChanges.getMappedTermUrl(), result.getMappedTermUrl());
+        assertEquals(withChanges.getSource(), result.getSource());
+        assertEquals(withChanges.getMappedTermLabel(), result.getMappedTermLabel());
+        assertEquals(withChanges.getEntityType(), result.getEntityType());
+    }
+
+    @Test
+    void update_statusChangedReviewToMapped_statusAndDateUpdatedAndSaveMethodCalled() {
+        MappingEntity original = mappingEntityBuilder
+            .setEntityType(EntityTypeName.Treatment)
+            .setValues(MappingEntityBuilder.createTreatmentValues("TRACE", "Aspirin"))
+            .setStatus(Status.REVIEW)
+            .build();
+        LocalDateTime yesterday = LocalDateTime.now().minusDays(1);
+        original.setDateUpdated(yesterday);
+
+        MappingEntity withChanges = mappingEntityBuilder
+            .setEntityType(EntityTypeName.Treatment)
+            .setValues(MappingEntityBuilder.createTreatmentValues("TRACE", "Aspirin"))
+            .setStatus(Status.MAPPED)
+            .build();
+
+        MappingEntity result = instance.update(original, withChanges, MappingType.MANUAL);
+
+        verify(mappingEntityRepository).save(result);
+        assertTrue(result.getDateUpdated().isAfter(yesterday), "Update date didn't change");
+        assertEquals(withChanges.getMappedTermUrl(), result.getMappedTermUrl());
+        assertEquals(withChanges.getSource(), result.getSource());
+        assertEquals(withChanges.getMappedTermLabel(), result.getMappedTermLabel());
+        assertEquals(withChanges.getEntityType(), result.getEntityType());
+    }
+
+    @Test
+    void update_statusChangedReviewToUnmapped_statusAndDateUpdatedAndSaveMethodCalled() {
+        MappingEntity original = mappingEntityBuilder
+            .setEntityType(EntityTypeName.Treatment)
+            .setValues(MappingEntityBuilder.createTreatmentValues("TRACE", "Aspirin"))
+            .setStatus(Status.REVIEW)
+            .build();
+        LocalDateTime yesterday = LocalDateTime.now().minusDays(1);
+        original.setDateUpdated(yesterday);
+
+        MappingEntity withChanges = mappingEntityBuilder
+            .setEntityType(EntityTypeName.Treatment)
+            .setValues(MappingEntityBuilder.createTreatmentValues("TRACE", "Aspirin"))
+            .setStatus(Status.UNMAPPED)
+            .build();
+
+        MappingEntity result = instance.update(original, withChanges, MappingType.MANUAL);
+
+        verify(mappingEntityRepository).save(result);
+        assertTrue(result.getDateUpdated().isAfter(yesterday), "Update date didn't change");
+        assertEquals(withChanges.getMappedTermUrl(), result.getMappedTermUrl());
+        assertEquals(withChanges.getSource(), result.getSource());
+        assertEquals(withChanges.getMappedTermLabel(), result.getMappedTermLabel());
+        assertEquals(withChanges.getEntityType(), result.getEntityType());
+    }
+
+    @Test
+    void update_statusChangedUnmappedToReviewTypeManual_Exception() {
+        MappingEntity original = mappingEntityBuilder
+            .setEntityType(EntityTypeName.Treatment)
+            .setValues(MappingEntityBuilder.createTreatmentValues("TRACE", "Aspirin"))
+            .setStatus(Status.UNMAPPED)
+            .build();
+        LocalDateTime yesterday = LocalDateTime.now().minusDays(1);
+        original.setDateUpdated(yesterday);
+
+        MappingEntity withChanges = mappingEntityBuilder
+            .setEntityType(EntityTypeName.Treatment)
+            .setValues(MappingEntityBuilder.createTreatmentValues("TRACE", "Aspirin"))
+            .setStatus(Status.REVIEW)
+            .build();
+
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+            () -> instance.update(original, withChanges, MappingType.MANUAL),
+            "Exception not thrown");
+        assertThat(
+            "Not expected message",
+            thrown.getMessage(),
+            is("Cannot change status from [Unmapped] to [Review] (method: Manual)"));
+    }
+
+}


### PR DESCRIPTION
Former Revise status is now Review, and will be set to automatic mappings and also available as a manual transition from Mapped.